### PR TITLE
chore: using @google/semantic-release-replace-plugin for pre-release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,13 +18,9 @@ jobs:
         with:
           token: ${{ secrets.OKP4_TOKEN }}
 
-      - name: Setup environment
-        uses: actions/setup-go@v2
-        with:
-          go-version: '1.17.0'
-
-      - run: |
-          go install github.com/piranha/goreplace@2.6
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
 
       - name: Release project
         uses: cycjimmy/semantic-release-action@v2
@@ -35,9 +31,11 @@ jobs:
             @semantic-release/changelog
             @semantic-release/exec
             @semantic-release/git
+            @google/semantic-release-replace-plugin
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GIT_AUTHOR_NAME: ${{ secrets.OKP4_BOT_GIT_AUTHOR_NAME }}
           GIT_AUTHOR_EMAIL: ${{ secrets.OKP4_BOT_GIT_AUTHOR_EMAIL }}
           GIT_COMMITTER_NAME: ${{ secrets.OKP4_BOT_GIT_COMMITTER_NAME }}
           GIT_COMMITTER_EMAIL: ${{ secrets.OKP4_BOT_GIT_COMMITTER_EMAIL }}
+          TODAY: ${{ steps.date.outputs.date }}

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -9,13 +9,35 @@ plugins:
   - - "@semantic-release/changelog"
     - changelogFile: CHANGELOG.md
       changelogTitle: "# OKP4 Ontology Changelog"
-  - - "@semantic-release/exec"
-    - prepareCmd: |
-        # Required goreplace:
-        # $ go install github.com/piranha/goreplace
-        echo "Bump ontology version to: ${nextRelease.version}"
-        goreplace -o "okp4\.ttl" 'owl:versionIRI\s+<(.+)\/(\d+\.\d+\.\d+)>' -r 'owl:versionIRI <$1/${nextRelease.version}>'
-        goreplace -o "okp4\.ttl" 'owl:versionInfo "v(\d+\.\d+\.\d+)"' -r 'owl:versionInfo \"v${nextRelease.version}\"'
+  - - '@google/semantic-release-replace-plugin'
+    - replacements:
+    - files: [ src/okp4.ttl ]
+      from: owl:versionIRI\s+<(.+)\/(\d+\.\d+\.\d+)>
+      to: 'owl:versionIRI <$1/${nextRelease.version}>'
+      countMatches: true
+      results:
+        - file: src/okp4.ttl
+          hasChanged: true
+          numMatches: 1
+          numReplacements: 1
+    - files: [ src/okp4.ttl ]
+      from: owl:versionInfo "v(\d+\.\d+\.\d+)"
+      to: 'owl:versionInfo "v${nextRelease.version}"'
+      countMatches: true
+      results:
+        - file: src/okp4.ttl
+          hasChanged: true
+          numMatches: 1
+          numReplacements: 1
+    - files: [ src/okp4.ttl ]
+      from: dcterms:created "\d+\-\d+\-\d+"
+      to: 'dcterms:created "${TODAY}"'
+      countMatches: true
+      results:
+        - file: src/okp4.ttl
+          hasChanged: true
+          numMatches: 1
+          numReplacements: 1
   - "@semantic-release/github"
   - - "@semantic-release/git"
     - assets:


### PR DESCRIPTION
https://github.com/okp4/product/issues/244

Tested locally, successfully until date replacement. It should work providing the fact that $TODAY env var is passed to the plugin.