### PR TITLE
Change ontology URI

### DIFF
--- a/src/okp4.ttl
+++ b/src/okp4.ttl
@@ -1,4 +1,4 @@
-@prefix : <https://ontology.okp4.com/core/> .
+@prefix : <https://ontology.okp4.space/core/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
@@ -6,9 +6,9 @@
 @prefix vann: <http://purl.org/vocab/vann/> .
 @prefix vs: <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
 
-<https://ontology.okp4.com/core>
+<https://ontology.okp4.space/core>
   a owl:Ontology ;
-  owl:versionIRI <https://ontology.okp4.com/core/1.0.0> ;
+  owl:versionIRI <https://ontology.okp4.space/core/1.0.0> ;
   owl:versionInfo "v1.0.0" ;
   dcterms:created "2021-10-11"^^xsd:date ;
   dcterms:language "EN" ;
@@ -28,7 +28,7 @@
   """@en ;
   rdfs:label "OKP4 Ontology"@en ;
   vann:preferredNamespacePrefix "okp4" ;
-  vann:preferredNamespaceUri "https://ontology.okp4.com/core" ;
+  vann:preferredNamespaceUri "https://ontology.okp4.space/core" ;
   vs:term_status "unstable"@en .
 
 # -- annotation properties


### PR DESCRIPTION
The `okp4.space` domain is now the true and only one domain for anything platform-related. Ontology URIs must therefore conform to it.