### PR TITLE
ci: fix incorrect github token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
             @semantic-release/git
             @google/semantic-release-replace-plugin
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.OKP4_TOKEN }}
           GIT_AUTHOR_NAME: ${{ secrets.OKP4_BOT_GIT_AUTHOR_NAME }}
           GIT_AUTHOR_EMAIL: ${{ secrets.OKP4_BOT_GIT_AUTHOR_EMAIL }}
           GIT_COMMITTER_NAME: ${{ secrets.OKP4_BOT_GIT_COMMITTER_NAME }}


### PR DESCRIPTION
Fix incorrect github token during release stage.

<img width="524" alt="image" src="https://user-images.githubusercontent.com/9574336/154728113-bf3cf893-d361-4ab2-9430-5413f39b57ad.png">

👉 Use OKP4 @bot-anik token instead.