### PR TITLE
build: disable directory browsing in apache2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ FROM httpd:2.4.51-alpine3.14
 
 WORKDIR /usr/local/apache2/htdocs/
 
-RUN rm -r ./*
+RUN  rm -r ./* \
+  && sed -i "s/Options Indexes FollowSymLinks/# Options Indexes FollowSymLinks/" ../conf/httpd.conf
 
 COPY --from=BUILD_IMAGE /var/build/ontology/documentation .


### PR DESCRIPTION
Disable directory listing (for obvious reasons) of apache2 by patching the Apache `httpd.conf` file by commenting the line that declares the `Options -Indexes ...` directive.