### PR TITLE
build: add missing resources (images, webvowl...)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,22 @@
 # ---
 FROM ghcr.io/okp4/widoco:1.4.15 AS BUILD_IMAGE
 
-WORKDIR /var/build/ontology/documentation
+WORKDIR /var/build/ontology
 
-COPY src ..
+COPY . .
 
 RUN  java -jar /usr/local/widoco/widoco.jar \
-        -ontFile ../okp4.ttl                \
-        -outFolder .                        \ 
+        -ontFile src/okp4.ttl               \
+        -outFolder documentation            \ 
         -htaccess                           \
-  && rm readme.md
+        -lang en                            \
+        -getOntologyMetadata                \
+        -includeImportedOntologies          \
+        -displayDirectImportsOnly           \
+        -webVowl                            \
+        -uniteSections                      \
+  && cp -R public/* documentation           \
+  && rm documentation/readme.md
 
 # ---
 FROM httpd:2.4.51-alpine3.14


### PR DESCRIPTION
Improve generated documentation in Docker image so that:
- all missing web resources (images...) are included
- the [WebVOWL](http://vowl.visualdataweb.org/webvowl/) diagram is displayed

This is similar to what produces the `make documentation` target.