### PR TITLE
build: fix mixed active content issue on browser

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN  java -jar /usr/local/widoco/widoco.jar \
         -webVowl                            \
         -uniteSections                      \
   && cp -R public/* documentation           \
+  && sed -i "s/http:\/\//https:\/\//" documentation/webvowl/css/*.css  \
   && rm documentation/readme.md
 
 # ---


### PR DESCRIPTION
## Issue

[Webvowl](http://vowl.visualdataweb.org/webvowl.html) imports google fonts using the unsecure `http` scheme:

```css
@import url(http://fonts.googleapis.com/css?family=Open+Sans);
/*----------------------------------------------
        WebVOWL page
----------------------------------------------*/
html {
    -ms-content-zooming: none;
}
...
```

This is forbidden by the browsers and leads to the [mixed active content](https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content) error.

<img width="956" alt="image" src="https://user-images.githubusercontent.com/9574336/155196142-7b98c6fd-fefd-44b5-8ba1-ed23a8bf36a7.png">

## Fix

This PR proposes to patch the content of the `Webvowl` css by replacing the `http` scheme with `https` when building the docker image.

