### PR TITLE
ci(workflow): edit .releaserc release rules

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -4,7 +4,20 @@ branches:
 repositoryUrl: "git@github.com:okp4/ontology.git"
 
 plugins:
-  - "@semantic-release/commit-analyzer"
+  - - "@semantic-release/commit-analyzer"
+    - releaseRules:
+        - type: build
+          release: patch
+        - type: ci
+          release: patch
+        - type: docs
+          release: patch
+        - type: style
+          release: patch
+        - type: refactor
+          release: patch
+        - type: chore
+          release: patch
   - "@semantic-release/release-notes-generator"
   - - "@semantic-release/changelog"
     - changelogFile: CHANGELOG.md


### PR DESCRIPTION
Add release rules, based on commits messages, in order to allow new release publish from the commit-analyser.