### PR TITLE
feat: insert shapefile mime types

### DIFF
--- a/src/vocab-mediatype.ttl
+++ b/src/vocab-mediatype.ttl
@@ -249,7 +249,7 @@ media-type:application_andrew-inset a skos:Concept ;
 
 media-type:application_geopackage a skos:Concept ;
   media-type:hasMediaType "application/geopackage+sqlite3" ;
-  skos:broader media-type:application_octet-stream 
+  skos:broader media-type:application_octet-stream ; 
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "GeoPackage"@en .
   
@@ -491,7 +491,7 @@ media-type:application_vndcorel-draw a skos:Concept ;
 
 media-type:application_vnddbf a skos:Concept ;
   media-type:hasMediaType "application/vnd.dbf" ;
-  skos:broader media-type:application_octet-stream 
+  skos:broader media-type:application_octet-stream ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Shapefile format .dbf extension"@en .
 
@@ -605,13 +605,13 @@ media-type:application_vndrn-realmedia a skos:Concept ;
 
 media-type:application_vndshp a skos:Concept ;
   media-type:hasMediaType "application/vnd.shp" ;
-  skos:broader media-type:application_octet-stream 
+  skos:broader media-type:application_octet-stream ; 
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Shapefile format .shp extension"@en .
 
 media-type:application_vndshx a skos:Concept ;
   media-type:hasMediaType "application/vnd.shx" ;
-  skos:broader media-type:application_octet-stream 
+  skos:broader media-type:application_octet-stream ; 
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Shapefile format .shx extension"@en .
 

--- a/src/vocab-mediatype.ttl
+++ b/src/vocab-mediatype.ttl
@@ -247,6 +247,12 @@ media-type:application_andrew-inset a skos:Concept ;
   skos:prefLabel "Mewnosodiad Andrew Toolkit"@cy ;
   skos:prefLabel "ajout Andrew Toolkit"@fr .
 
+media-type:application_geopackage a skos:Concept ;
+  media-type:hasMediaType "application/geopackage+sqlite3" ;
+  skos:broader media-type:application_octet-stream 
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "GeoPackage"@en .
+  
 media-type:application_illustrator a skos:Concept ;
   media-type:hasMediaType "application/illustrator" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;

--- a/src/vocab-mediatype.ttl
+++ b/src/vocab-mediatype.ttl
@@ -489,6 +489,12 @@ media-type:application_vndcorel-draw a skos:Concept ;
   skos:prefLabel "Σχέδιο Corel Draw "@el ;
   skos:prefLabel "코렐 드로우 드로잉"@ko .
 
+media-type:application_vnddbf a skos:Concept ;
+  media-type:hasMediaType "application/vnd.dbf" ;
+  skos:broader media-type:application_octet-stream 
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Shapefile format .dbf extension"@en .
+
 media-type:application_vndhp-hpgl a skos:Concept ;
   media-type:hasMediaType "application/vnd.hp-hpgl" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
@@ -596,6 +602,18 @@ media-type:application_vndrn-realmedia a skos:Concept ;
   skos:prefLabel "document RealAudio/Video"@fr ;
   skos:prefLabel "Έγγραφο RealAudio/Video"@el ;
   skos:prefLabel "리얼오디오/비디오 문서"@ko .
+
+media-type:application_vndshp a skos:Concept ;
+  media-type:hasMediaType "application/vnd.shp" ;
+  skos:broader media-type:application_octet-stream 
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Shapefile format .shp extension"@en .
+
+media-type:application_vndshx a skos:Concept ;
+  media-type:hasMediaType "application/vnd.shx" ;
+  skos:broader media-type:application_octet-stream 
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Shapefile format .shx extension"@en .
 
 media-type:application_vndstardivisioncalc a skos:Concept ;
   media-type:hasMediaType "application/vnd.stardivision.calc" ;
@@ -1573,12 +1591,6 @@ media-type:application_x-gettext-translation a skos:Concept ;
   skos:prefLabel "translated messages (machine-readable)"@en ;
   skos:prefLabel "übersetzte Meldungen (maschinenlesbar)"@de .
 
-media-type:application_x-gis a skos:Concept ;
-  media-type:hasMediaType "application/x-gis" ;
-  skos:broader media-type:application_octet-stream 
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
-  skos:prefLabel "Shapefile"@en .
-
 media-type:application_x-glade a skos:Concept ;
   media-type:hasMediaType "application/x-glade" ;
   skos:broader media-type:text_plain ;
@@ -2303,12 +2315,6 @@ media-type:application_x-sc a skos:Concept ;
   media-type:hasMediaType "application/x-sc" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> .
 
-media-type:application_x-shapfile a skos:Concept ;
-  media-type:hasMediaType "application/x-shapefile" ;
-  skos:broader media-type:application_octet-stream 
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
-  skos:prefLabel "Shapefile"@en .
-  
 media-type:application_x-shar a skos:Concept ;
   media-type:hasMediaType "application/x-shar" ;
   skos:broader media-type:text_plain ;

--- a/src/vocab-mediatype.ttl
+++ b/src/vocab-mediatype.ttl
@@ -1567,6 +1567,12 @@ media-type:application_x-gettext-translation a skos:Concept ;
   skos:prefLabel "translated messages (machine-readable)"@en ;
   skos:prefLabel "übersetzte Meldungen (maschinenlesbar)"@de .
 
+media-type:application_x-gis a skos:Concept ;
+  media-type:hasMediaType "application/x-gis" ;
+  skos:broader media-type:application_octet-stream 
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Shapefile"@en .
+
 media-type:application_x-glade a skos:Concept ;
   media-type:hasMediaType "application/x-glade" ;
   skos:broader media-type:text_plain ;
@@ -2291,6 +2297,12 @@ media-type:application_x-sc a skos:Concept ;
   media-type:hasMediaType "application/x-sc" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> .
 
+media-type:application_x-shapfile a skos:Concept ;
+  media-type:hasMediaType "application/x-shapefile" ;
+  skos:broader media-type:application_octet-stream 
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Shapefile"@en .
+  
 media-type:application_x-shar a skos:Concept ;
   media-type:hasMediaType "application/x-shar" ;
   skos:broader media-type:text_plain ;


### PR DESCRIPTION
feat: insert shapefile mime types

I have inserted `application/x-shapefile` and `application/x-gis`  both MIME types for the ``shapefile`` format (``.shp`` ). The shapefile format is a geospatial vector data format for geographic information system (GIS) software.

See more [here](https://en.wikipedia.org/wiki/Shapefile).