### PR TITLE
Feat/rm order auth cred

### DIFF
--- a/docs/schemas/credential-digital-service-authentication.md
+++ b/docs/schemas/credential-digital-service-authentication.md
@@ -27,21 +27,11 @@ Here are the namespaces used in this schema:
 
 ### Description
 
-The Digital Service Authentication Credential is a formal declaration used to authenticate a Digital Service against another in the purpose of fulfilling of a Digital Service Execution Order.
+The Digital Service Authentication Credential is a formal declaration used to authenticate a Digital Service against another.
 
-In these credentials, both the subject and the issuer are the Digital Service to be authenticated. The credential contains the needed element to verify the authentication has been requested.
+In these credentials, both the subject and the issuer are the Digital Service to be authenticated. The credential carries the needed element to verify the requested authentication.
 
 ### Properties
-
-#### For order
->
-> **IRI**: [credential-digital-service-authentication:forOrder](https://w3id.org/axone/ontology/v3/schema/credential/digital-service/authentication/forOrder)
->
-> **Domain**:&nbsp;[credential-digital-service-authentication:DigitalServiceAuthenticationCredential](https://w3id.org/axone/ontology/v3/schema/credential/digital-service/authentication/DigitalServiceAuthenticationCredential)
->
-> **Range**:&nbsp;[xsd:anyURI](http://www.w3.org/2001/XMLSchema#anyURI)
-
-The Digital Service Execution Order served by this authentication.
 
 #### To service
 >

--- a/src/schema/digital-service/credential-digital-service-authentication.ttl
+++ b/src/schema/digital-service/credential-digital-service-authentication.ttl
@@ -7,18 +7,10 @@
 :DigitalServiceAuthenticationCredential a rdfs:Class ;
   rdfs:label "Digital Service Authentication Credential"@en ;
   rdfs:comment """
-  The Digital Service Authentication Credential is a formal declaration used to authenticate a Digital Service against another in the purpose of fulfilling of a Digital Service Execution Order.
+  The Digital Service Authentication Credential is a formal declaration used to authenticate a Digital Service against another.
 
-  In these credentials, both the subject and the issuer are the Digital Service to be authenticated. The credential contains the needed element to verify the authentication has been requested.
+  In these credentials, both the subject and the issuer are the Digital Service to be authenticated. The credential carries the needed element to verify the requested authentication.
   """@en .
-
-:forOrder a rdf:Property ;
-  rdfs:label "for order"@en ;
-  rdfs:comment """
-  The Digital Service Execution Order served by this authentication.
-  """@en ;
-  schema:domainIncludes :DigitalServiceAuthenticationCredential ;
-  schema:rangeIncludes xsd:anyURI .
 
 :toService a rdf:Property ;
   rdfs:label "to service"@en ;


### PR DESCRIPTION
Remove the execution order reference from the authentication credential.

## Details

The `forOrder` property of the `DigitalServiceAuthenticationCredential` purpose was to identify the execution order concerned by the authentication intent. This was restrictive as prevents authentication in other contexts, and necessary as on-chain access rules are able to deduce its presence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
  - Refined descriptions and properties in the Digital Service Authentication Credential documentation for improved clarity.
  - Removed redundant information to streamline the understanding of the credential's function.

- **Schema Updates**
  - Revised the RDF schema for Digital Service Authentication Credential, including concise descriptions and removal of the `forOrder` property to focus on core functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->