### PR TITLE
refactor(schema): categorize proof of participation VC under proof

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -93,7 +93,7 @@ jobs:
         env:
           NUMBER_OF_THE_BEAST: 666
 
-      - name: Check Git diff in generated files (proto + docs)
+      - name: Check Git diff in generated files (docs)
         run: |
           if [[ $(git status -s) != "" ]]; then
             >&2 echo "❌ There is a diff between generated files and source code"

--- a/docs/schemas/credential-proof-participation.md
+++ b/docs/schemas/credential-proof-participation.md
@@ -5,9 +5,9 @@ sidebar_position: 9
 
 # Proof of participation credential
 
-> **Name**: `credential-proof-of-participation`
+> **Name**: `credential-proof-participation`
 >
-> **Namespace**: [https://w3id.org/axone/ontology/v4/schema/credential/proof-of-participation/](https://w3id.org/axone/ontology/v4/schema/credential/proof-of-participation/)
+> **Namespace**: [https://w3id.org/axone/ontology/v4/schema/credential/proof/participation/](https://w3id.org/axone/ontology/v4/schema/credential/proof/participation/)
 
 ## Namespaces
 
@@ -18,11 +18,11 @@ Here are the namespaces used in this schema:
 - `skos`: [http://www.w3.org/2004/02/skos/core#](http://www.w3.org/2004/02/skos/core#)
 - `dcterms`: [http://purl.org/dc/terms/](http://purl.org/dc/terms/)
 - `schema`: [http://schema.org/](http://schema.org/)
-- `credential-proof-of-participation`: [https://w3id.org/axone/ontology/v4/schema/credential/proof-of-participation/](https://w3id.org/axone/ontology/v4/schema/credential/proof-of-participation/)
+- `credential-proof-participation`: [https://w3id.org/axone/ontology/v4/schema/credential/proof/participation/](https://w3id.org/axone/ontology/v4/schema/credential/proof/participation/)
 
 ## Verifiable Credential
 
-> **IRI**: [credential-proof-of-participation:ProofOfParticipationCredential](https://w3id.org/axone/ontology/v4/schema/credential/proof-of-participation/ProofOfParticipationCredential)
+> **IRI**: [credential-proof-participation:ProofOfParticipationCredential](https://w3id.org/axone/ontology/v4/schema/credential/proof/participation/ProofOfParticipationCredential)
 
 ### Description
 
@@ -33,11 +33,11 @@ The event is linked using `:participatedIn`, which references an instance of [sc
 
 ### Examples
 
-```json title="katai-proof-of-participation.jsonld"
+```json title="katai-proof-participation.jsonld"
 {
     "@context": [
         "https://www.w3.org/2018/credentials/v1",
-        "https://w3id.org/axone/ontology/v4/schema/credential/proof-of-participation/",
+        "https://w3id.org/axone/ontology/v4/schema/credential/proof/participation/",
         "https://schema.org"
     ],
     "type": [
@@ -67,9 +67,9 @@ The event is linked using `:participatedIn`, which references an instance of [sc
 
 #### Participated in
 >
-> **IRI**: [credential-proof-of-participation:participatedIn](https://w3id.org/axone/ontology/v4/schema/credential/proof-of-participation/participatedIn)
+> **IRI**: [credential-proof-participation:participatedIn](https://w3id.org/axone/ontology/v4/schema/credential/proof/participation/participatedIn)
 >
-> **Domain**:&nbsp;[credential-proof-of-participation:ProofOfParticipationCredential](https://w3id.org/axone/ontology/v4/schema/credential/proof-of-participation/ProofOfParticipationCredential)
+> **Domain**:&nbsp;[credential-proof-participation:ProofOfParticipationCredential](https://w3id.org/axone/ontology/v4/schema/credential/proof/participation/ProofOfParticipationCredential)
 >
 > **Range**:&nbsp;[schema:Event](http://schema.org/Event)
 

--- a/src/example/proof/katai-proof-participation.jsonld
+++ b/src/example/proof/katai-proof-participation.jsonld
@@ -1,7 +1,7 @@
 {
     "@context": [
         "https://www.w3.org/2018/credentials/v1",
-        "https://w3id.org/axone/ontology/v$major/schema/credential/proof-of-participation/",
+        "https://w3id.org/axone/ontology/v$major/schema/credential/proof/participation/",
         "https://schema.org"
     ],
     "type": [

--- a/src/schema/proof/credential-proof-participation.ttl
+++ b/src/schema/proof/credential-proof-participation.ttl
@@ -1,6 +1,6 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix : <https://w3id.org/axone/ontology/v$major/schema/credential/proof-of-participation/> .
+@prefix : <https://w3id.org/axone/ontology/v$major/schema/credential/proof/participation/> .
 @prefix schema: <http://schema.org/> .
 
 :ProofOfParticipationCredential a rdfs:Class ;


### PR DESCRIPTION
Self explanatory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated context URL for proof of participation credential
	- Modified namespace prefix for proof of participation ontology

- **Chores**
	- Simplified GitHub workflow linting configuration by removing proto file check
	- Renamed linting step to focus on documentation files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->